### PR TITLE
Recipesコントローラのストロングパラメータを修正完了

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -38,7 +38,7 @@ module Api
         recipe = @user.recipes.build(recipe_params)
 
         if recipe.save
-          render json: { message: "レシピが作成されました", recipe: recipe }, status: :created
+          render json: { message: "レシピが作成されました", recipe: recipe, ingredient: recipe.ingredients }, status: :created
         else
           render json: { error: "レシピの作成に失敗しました", details: recipe.errors.messages[:name] }, status: :unprocessable_entity
         end
@@ -46,7 +46,7 @@ module Api
 
       def update
         if @recipe.update(recipe_params)
-          render json: { message: "レシピが更新されました", recipe: @recipe }, status: :ok
+          render json: { message: "レシピが更新されました", recipe: @recipe, ingredient: @recipe.ingredients }, status: :ok
         else
           render json: { error: "レシピの更新に失敗しました", details: @recipe.errors.messages[:name] }, status: :unprocessable_entity
         end
@@ -85,7 +85,10 @@ module Api
 
       # ストロングパラメータ
       def recipe_params
-        params.require(:recipe).permit(:name, :notes)
+        params.require(:recipe).permit(
+          :name, :notes,
+          ingredients_attributes: [:id, :name, :quantity, :unit, :category, :_destroy] # "_destroy": trueで指定IDの材料を削除
+        )
       end
     end
   end


### PR DESCRIPTION
下記、確認済み

・`ingredients_attributes`として材料データを許容するようストロングパタメータに追加
・作成・更新した材料データをJSONで返すよう`create`と`update`アクションに追記

Postmanから材料データ作成と更新が問題ないこと、且つレスポンスのJSONに操作した材料データが含まれること確認

closes #62 