### PR TITLE
メール内リンク押下時のリダイレクト先URLをNext.jsページに変更

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -66,12 +66,12 @@ DeviseTokenAuth.setup do |config|
 
   # メールアドレス認証後のリダイレクトURL
   # NOTE: URLは後で適切にする
-  config.default_confirm_success_url = "http://localhost:3010"
+  config.default_confirm_success_url = "http://localhost:3000"
 
   # ユーザー認証情報の代わりにパスワードリセットトークンをリダイレクト先URLに含める
   config.require_client_password_reset_token = true
 
   # パスワードリセットリンク押下後のリダイレクトURL
   # NOTE: URLは後で適切にする
-  config.default_password_reset_url = "http://localhost:3010"
+  config.default_password_reset_url = "http://localhost:3000/password-reset"
 end


### PR DESCRIPTION
開発環境向け。下記に変更。

アカウント認証時：**http://localhost:3000**
パスワードリセット時：**http://localhost:3000/password-reset**