### PR TITLE
CORSでエクスポーズするヘッダーにページネーション情報を追加

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,7 +11,10 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
-      expose:  ["access-token", "expiry", "token-type", "uid", "client"],
+      expose:  [
+        "access-token", "expiry", "token-type", "uid", "client",
+        "current-page", "page-items", "total-count", "total-pages"
+      ],
       methods: [:get, :post, :put, :patch, :delete, :options, :head]
   end
 end


### PR DESCRIPTION
`cors.rb`の`expose: []` に下記を追加

- **current-page**
- **page-items**
- **total-count**
- **total-pages**

クライアントの開発者ツールにて上記情報がレスポンスヘッダーにあること確認OK

fixes #150 