### PR TITLE
Nginxが返すエラーページへの直接アクセスをブロック

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,8 +1,8 @@
 ## Nginxの設定
 
-# Nginxが受け取ったリクエストをPumaへ送信
+# Pumaとの通信に Unixドメインソケット を利用
 upstream api {
-  server unix:///app/tmp/sockets/puma.sock; # UNIXドメインソケット通信を適用
+  server unix:///app/tmp/sockets/puma.sock;
 }
 
 server {
@@ -13,27 +13,35 @@ server {
   access_log /var/log/nginx/access.log;
   error_log  /var/log/nginx/error.log;
 
-  # ドキュメントルートの指定
+  # 静的ファイルのルート（Railsの /public を参照）
   root /app/public;
 
   # クライアントがアップロード可能な最大リクエストサイズ(m = MB)
   client_max_body_size 100m;
 
-  # 各エラー時に表示するページを指定
+  # エラーページ指定
   error_page 404             /404.html;
   error_page 502 503 504 505 /500.html;
 
-  # リクエストされたファイル($uri)が存在すれば返す。存在しないならRailsへルーティング。
+  # エラーページへの直接アクセスをブロック
+  location = /404.html {
+    internal;
+  }
+
+  location = /500.html {
+    internal;
+  }
+
+  # リクエストファイル($uri)が存在すれば返し、なければRailsへルーティング
   try_files $uri @api;
 
-  # クライアントとの接続の維持時間
-  keepalive_timeout 5;
-
-  # リバースプロキシ経由の元情報をRailsへ転送
+  # リバースプロキシ設定
   location @api {
     proxy_pass       http://api;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
+
+  keepalive_timeout 5;
 }


### PR DESCRIPTION
- すでに静的ファイルはRailsからではなくNginxから返却するよう設定済み
- エラーページへ直接アクセスできないよう設定
- コメントを改善

時間あったら404ページと500ページを作成する & `/public` に配置する

closes #161 