### PR TITLE
本番環境でメール内リンク押下時にNext.jsの正しいURLへ遷移するよう修正

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -4,11 +4,12 @@
 
 <p>以下のリンクを押して、本登録を完了してください。</p><br>
 
+<% confirmation_link = "#{ENV.fetch("DEFAULT_CONFIRM_SUCCESS_URL", "http://localhost:3000")}?account_confirmation_success=true" %>
+
 <p>
   <%= link_to "アカウントを認証する", confirmation_url(@resource, {
     confirmation_token: @token,
-    config: message['client-config'].to_s,
-    redirect_url: message['redirect-url']
+    redirect_url: confirmation_link
   }).html_safe %>
 </p>
 

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,11 +2,12 @@
 
 <p>パスワードリセットのリクエストを受け付けました。以下のリンクから手続きをしてください。</p><br>
 
+<% reset_link = "#{ENV.fetch("DEFAULT_PASSWORD_RESET_URL", "http://localhost:3000/password-reset")}?reset_password_token=#{@token}" %>
+
 <p>
   <%= link_to "パスワードをリセットする", edit_password_url(@resource, {
     reset_password_token: @token,
-    config: message['client-config'].to_s,
-    redirect_url: message['redirect-url'].to_s
+    redirect_url: reset_link
   }).html_safe %>
 </p>
 


### PR DESCRIPTION
#178 下記二つ対応

- アカウント認証メール
- パスワードリセットメール

追記：
バグ解消されていないので引き続き対応