### PR TITLE
aws-sdk-s3を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem "devise_token_auth"
 # Pagination
 gem "pagy", "~> 9.3"
 
+# Upload Image for Prod
+gem "aws-sdk-s3", require: false
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,24 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1116.0)
+    aws-sdk-core (3.225.2)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.105.0)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.189.1)
+      aws-sdk-core (~> 3, >= 3.225.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -136,6 +154,7 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.9.1)
     language_server-protocol (3.17.0.4)
     launchy (3.1.0)
@@ -322,6 +341,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_storage_validations (~> 2.0, >= 2.0.2)
+  aws-sdk-s3
   bootsnap
   brakeman
   debug


### PR DESCRIPTION
S3を利用しない方針にしたため**aws-sdk-s3**を一度アンインストール

しかし、ActiveStorage導入済みのため（プロフィール画像アップロード用）aws-sdk-s3がないとデプロイエラーになる
よって、再びインストールして元に戻した