### PR TITLE
テストカバレッジ算出の設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,7 @@
 # Task definition created from task_definition.json.template
 ecs/task_definition.json
 
+# Test coverage
+/coverage/
+
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -59,4 +59,7 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  # Calculate test coverage
+  gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,7 @@ GEM
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 8.1)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.1)
     factory_bot (6.5.1)
@@ -317,6 +318,12 @@ GEM
       ffi (~> 1.12)
       logger
     securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     stringio (3.1.2)
     thor (1.3.2)
     timeout (0.4.3)
@@ -360,6 +367,7 @@ DEPENDENCIES
   rails (~> 7.2.2, >= 7.2.2.1)
   rspec-rails (~> 7.1.0)
   rubocop-rails-omakase
+  simplecov
   tzinfo-data
 
 BUNDLED WITH

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,9 @@
+# テストカバレッジ算出
+require "simplecov"
+SimpleCov.start "rails" do
+  add_filter "/spec/"
+end
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] = 'test'


### PR DESCRIPTION
下記、対応済み

- **simplecov**を導入
- `spec`ディレクトリをカバレッジ計算対象から除外
- `coverage`をgit管理から除外

rspec実行時にテスト結果と共にカバレッジ出力される & `coverage`ディレクトリ作成されること確認OK

現在のカバレッジ → **83.05**%

closes #206 